### PR TITLE
Do not return error if input dir does not exist

### DIFF
--- a/device_nodes.go
+++ b/device_nodes.go
@@ -89,6 +89,9 @@ func hidrawNodes(ctx context.Context, devicePath string) ([]string, error) {
 func eventNodes(devicePath string) ([]string, error) {
 	eventNodes := make([]string, 0)
 	directories, err := ioutil.ReadDir(path.Join(devicePath, "input"))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When I call the `Device.HidrawNodes()` method, the error `open /sys/.../input: no such file or directory` is returned because the device I am using does not have any event nodes.

This error will bubble up causing the method to return the error instead of returning a list of the device's hidraw nodes.

I made a simple change to not return an error if the error is `ErrNotExist`.